### PR TITLE
Be clear that cutoff value is included in p-value

### DIFF
--- a/server.R
+++ b/server.R
@@ -141,7 +141,7 @@ observeEvent( input$null_p, {
 output$Cat1TestXtremes <- renderUI({
   fluidRow(
     column(3,  
-           h4("Count values")
+           h4("Count values equal to or")
     ),
     column(4,
            tags$div(style="width: 200px",


### PR DESCRIPTION
At least one of my groups was concerned about this.

For 1 cat tests, change wording to  "Count values equal to or (greater|less|more extreme) than ..."
